### PR TITLE
Uses `response.raise_for_status()` to catch errors.

### DIFF
--- a/dandelion/base.py
+++ b/dandelion/base.py
@@ -92,10 +92,10 @@ class BaseDandelionRequest(object):
             response = None
             try:
                 response = self._do_raw_request(url, params, method, **kwargs)
-                if response.ok:
-                    self.cache.set(cache_key, response)
+                response.raise_for_status()
+                self.cache.set(cache_key, response)
             except RequestException as e:
-                raise DandelionException(e, response=response)
+                raise DandelionException(e, response=response) from e
 
         obj = response.json(object_hook=AttributeDict)
         if not response.ok:


### PR DESCRIPTION
The initial issue was triggered by Timeout errors not getting raised.

This catches that and other issues and properly raises the exception.